### PR TITLE
chore(dev): add example environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example `.env` file for the Stave project, loaded by `just`
+# Copy this file to `.env` and fill in the appropriate values
+# `.env` should not be committed to version control - it's .gitignored
+
+# Django secret key (replace with a secure key for production)
+DJANGO_SECRET_KEY=django-insecure-secret-key
+# Debug mode (False in production)
+DEBUG=True


### PR DESCRIPTION
In the interest of getting up and running easily, add some required keys to an example file. These can be extended as more development configurations are used.