### PR TITLE
chore: mark migration `RunPython` elidable

### DIFF
--- a/stave/migrations/0040_league_time_zone.py
+++ b/stave/migrations/0040_league_time_zone.py
@@ -645,5 +645,5 @@ class Migration(migrations.Migration):
                 max_length=256,
             ),
         ),
-        migrations.RunPython(update_timezones),
+        migrations.RunPython(update_timezones, elidable=True),
     ]

--- a/stave/migrations/0043_remove_application_invitation_email_sent_and_more.py
+++ b/stave/migrations/0043_remove_application_invitation_email_sent_and_more.py
@@ -51,7 +51,7 @@ class Migration(migrations.Migration):
                 ]
             ),
         ),
-        migrations.RunPython(convert_statuses),
+        migrations.RunPython(convert_statuses, elidable=True),
         migrations.RemoveField(
             model_name="application",
             name="invitation_email_sent",

--- a/stave/migrations/0048_messagetemplate_name.py
+++ b/stave/migrations/0048_messagetemplate_name.py
@@ -36,5 +36,5 @@ class Migration(migrations.Migration):
             name="name",
             field=models.CharField(blank=True, max_length=256, null=True),
         ),
-        migrations.RunPython(set_messagetemplate_names),
+        migrations.RunPython(set_messagetemplate_names, elidable=True),
     ]

--- a/stave/migrations/0050_alter_rolegroup_options_and_more.py
+++ b/stave/migrations/0050_alter_rolegroup_options_and_more.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
             name="insurance",
             field=models.CharField(blank=True, max_length=256, null=True),
         ),
-        migrations.RunPython(migrate_insurance_field),
+        migrations.RunPython(migrate_insurance_field, elidable=True),
         migrations.RemoveField(
             model_name="user",
             name="wftda_insurance_number",


### PR DESCRIPTION
When using a `RunPython` command in a migration, this command lives on forever in the migrations code, but is never expected to be run again - especially since there's no `reverse_code` param passed to restore previous state, making them irreversible.

Marking them as `elibable=True` enables the `squashmigrations` command to know that the operations contained in these statements should not attempt to be carried forward in the event of a squash, rather the engine will remove them completely.
This should only be done for model behavior that has been changed, or of the operation applies strictly to live/prod data, and does not apply to dev/testing.

Refs: https://docs.djangoproject.com/en/5.2/ref/migration-operations/#django.db.migrations.operations.RunPython
Refs: https://docs.djangoproject.com/en/5.2/topics/migrations/#migration-squashing