### PR TITLE
feat: split out settings per environment

### DIFF
--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,2 +1,2 @@
-DEBUG=True
+DJANGO_ENV=development
 DJANGO_SECRET_KEY=django-insecure-secret-key

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,29 @@
 # Copy this file to `.env` and fill in the appropriate values
 # `.env` should not be committed to version control - it's .gitignored
 
-# Django secret key (replace with a secure key for production)
+# Django Environment Configuration
+# Set to 'development' or 'production'
+DJANGO_ENV=development
+
+# Django Secret Key (replace with a secure key for production)
 DJANGO_SECRET_KEY=django-insecure-secret-key
-# Debug mode (False in production)
-DEBUG=True
+
+# Database URL (optional, defaults to SQLite in development)
+# DATABASE_URL=postgresql://user:password@localhost/dbname
+
+# Debug mode (only used if explicitly set)
+# DEBUG=True
+
+# Sentry DSN for error tracking (production)
+# SENTRY_DSN=https://...@sentry.io/...
+
+# Email configuration
+# EMAIL_BACKEND=django.core.email.backends.smtp.EmailBackend
+# RESEND_API_KEY=your-resend-api-key
+
+# Google OAuth
+# GOOGLE_CLIENT_ID=your-client-id
+# GOOGLE_CLIENT_SECRET=your-client-secret
+
+# Media files location
+# MEDIA_ROOT=images

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV HOME=/home/app
+ENV DJANGO_ENV=production
 
 RUN addgroup --system app && adduser --system app --ingroup app
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR $HOME
 USER app
 COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
-RUN uv sync --frozen
+RUN uv sync --frozen --no-dev
 
 COPY --chown=app:app . .
 
-RUN uv run manage.py collectstatic --noinput
+RUN uv run --no-dev manage.py collectstatic --noinput
 CMD ["/home/app/docker/entrypoint.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.13"
 dependencies = [
     "django>=5.1.4",
     "django-allauth[mfa,socialaccount]>=65.3.1",
-    "django-extensions>=3.2.3",
     "django-htmx>=1.21.0",
     "pillow>=11.1.0",
     "django-markdownify>=0.9.5",
@@ -27,11 +26,15 @@ dependencies = [
     "whitenoise>=6.9.0",
     "sentry-sdk[django]>=2.24.0",
     "django-anymail[amazon-ses]>=13.0",
-    "django-debug-toolbar>=5.2.0",
     "django-meta>=2.5.0",
-    "pytest-django>=4.11.1",
 ]
 
+[dependency-groups]
+dev = [
+    "django-debug-toolbar>=5.2.0",
+    "django-extensions>=3.2.3",
+    "pytest-django>=4.11.1",
+]
 
 [tool.basedpyright]
 venv = ".venv"

--- a/stave/settings/__init__.py
+++ b/stave/settings/__init__.py
@@ -1,0 +1,17 @@
+"""
+Settings module that loads the appropriate configuration based on environment.
+"""
+
+import os
+
+# Determine which settings module to use based on DJANGO_ENV
+env = os.environ.get("DJANGO_ENV", "development")
+
+if env == "production":
+    from .production import *  # noqa
+elif env == "development":
+    from .development import *  # noqa
+else:
+    raise ValueError(
+        f"Unknown DJANGO_ENV: {env}. Must be 'development' or 'production'"
+    )

--- a/stave/settings/development.py
+++ b/stave/settings/development.py
@@ -1,0 +1,39 @@
+"""
+Development-specific settings.
+"""
+
+import os
+
+from .base import *  # noqa
+from .base import INSTALLED_APPS, MIDDLEWARE
+
+# Debug mode
+DEBUG = True
+
+# Development-specific apps
+INSTALLED_APPS += [
+    "debug_toolbar",
+    "django_extensions",  # Useful development tools like shell_plus
+]
+
+# Add debug toolbar middleware at the beginning for development
+MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+
+# Debug toolbar configuration
+INTERNAL_IPS = [
+    "127.0.0.1",
+    "localhost",
+]
+
+# Development email backend - Use console backend for local development
+if not os.environ.get("EMAIL_BACKEND"):
+    EMAIL_BACKEND = "django.core.email.backends.console.EmailBackend"
+
+# Allow verbose error pages
+DEBUG_PROPAGATE_EXCEPTIONS = True
+
+# Don't use Sentry in development unless explicitly configured
+if not os.environ.get("SENTRY_DSN"):
+    import sentry_sdk
+
+    sentry_sdk.init(dsn="")  # Disable Sentry

--- a/stave/settings/production.py
+++ b/stave/settings/production.py
@@ -1,0 +1,8 @@
+"""
+Production-specific settings.
+"""
+
+from .base import *  # noqa
+
+# Security settings
+DEBUG = False

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -698,8 +698,6 @@ dependencies = [
     { name = "django-allauth", extra = ["mfa", "socialaccount"] },
     { name = "django-anymail", extra = ["amazon-ses"] },
     { name = "django-apscheduler" },
-    { name = "django-debug-toolbar" },
-    { name = "django-extensions" },
     { name = "django-htmx" },
     { name = "django-ical" },
     { name = "django-markdownify" },
@@ -710,10 +708,16 @@ dependencies = [
     { name = "gunicorn" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
-    { name = "pytest-django" },
     { name = "python-dotenv" },
     { name = "sentry-sdk", extra = ["django"] },
     { name = "whitenoise" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "django-debug-toolbar" },
+    { name = "django-extensions" },
+    { name = "pytest-django" },
 ]
 
 [package.metadata]
@@ -723,8 +727,6 @@ requires-dist = [
     { name = "django-allauth", extras = ["mfa", "socialaccount"], specifier = ">=65.3.1" },
     { name = "django-anymail", extras = ["amazon-ses"], specifier = ">=13.0" },
     { name = "django-apscheduler", specifier = ">=0.7.0" },
-    { name = "django-debug-toolbar", specifier = ">=5.2.0" },
-    { name = "django-extensions", specifier = ">=3.2.3" },
     { name = "django-htmx", specifier = ">=1.21.0" },
     { name = "django-ical", specifier = ">=1.9.2" },
     { name = "django-markdownify", specifier = ">=0.9.5" },
@@ -735,10 +737,16 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "pillow", specifier = ">=11.1.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
-    { name = "pytest-django", specifier = ">=4.11.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "sentry-sdk", extras = ["django"], specifier = ">=2.24.0" },
     { name = "whitenoise", specifier = ">=6.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "django-debug-toolbar", specifier = ">=5.2.0" },
+    { name = "django-extensions", specifier = ">=3.2.3" },
+    { name = "pytest-django", specifier = ">=4.11.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduces the need for a `DJANGO_ENV` variable, defaults to
development, and `Dockerfile` defaults to production.
