### PR TITLE
test: add behavioral testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      DJANGO_SECRET_KEY: django-insecure-secret-key
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           flakes-from-devshell: true
           script: |
             uv run pytest
+            just behave
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/features/README.md
+++ b/features/README.md
@@ -1,0 +1,21 @@
+# Behavioral Tests
+
+This directory contains [behave](https://behave.readthedocs.io/) tests for Stave.
+Behave is a BDD ([Behavior Driven Development](https://en.wikipedia.org/wiki/Behavior-driven_development)) framework for Python
+that allows you to write tests in a natural language style, using [Gherkin](https://cucumber.io/docs/gherkin/reference) syntax.
+
+This is extended with [behave-django](https://behave-django.readthedocs.io/) to provide Django-specific testing capabilities.
+
+## Running the Tests
+
+To run the tests, execute from the root of the repository:
+
+```bash
+just behave
+```
+
+If you want to specify a particular feature file, you can do so by providing the path to the file:
+
+```bash
+just behave features/admin_login.feature
+```

--- a/features/admin_login.feature
+++ b/features/admin_login.feature
@@ -1,0 +1,7 @@
+Feature: Django Admin Authentication
+
+Scenario: Stave admin user can log in to Django Admin
+    Given a Stave admin user exists
+    When the user navigates to the Django Admin login page
+    And the user enters valid credentials
+    Then the Django Admin dashboard is displayed

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,3 +1,5 @@
+import os
+
 BEHAVE_DEBUG_ON_ERROR = False
 
 
@@ -7,6 +9,8 @@ def setup_debug_on_error(userdata):
 
 
 def before_all(context):
+    # Set Django settings for testing - behave_django will handle Django setup
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "stave.settings.development")
     setup_debug_on_error(context.config.userdata)
 
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,23 @@
+BEHAVE_DEBUG_ON_ERROR = False
+
+
+def setup_debug_on_error(userdata):
+    global BEHAVE_DEBUG_ON_ERROR
+    BEHAVE_DEBUG_ON_ERROR = userdata.getbool("BEHAVE_DEBUG_ON_ERROR")
+
+
+def before_all(context):
+    setup_debug_on_error(context.config.userdata)
+
+
+def after_step(context, step):
+    if BEHAVE_DEBUG_ON_ERROR and step.status == "failed":
+        import sys
+        import pdb
+
+        old_stdout = sys.stdout
+        sys.stdout = sys.__stdout__
+        try:
+            pdb.post_mortem(step.exc_traceback)
+        finally:
+            sys.stdout = old_stdout

--- a/features/steps/admin_login.py
+++ b/features/steps/admin_login.py
@@ -1,0 +1,44 @@
+from behave import given, when, then
+from django.contrib.auth import get_user_model
+from bs4 import BeautifulSoup
+
+
+@given("a Stave admin user exists")
+def given_superuser_exists(context):
+    User = get_user_model()
+    email = "admin@example.com"
+    password = "password123"
+    context.superuser = User.objects.create(
+        email=email, is_superuser=True, is_staff=True
+    )
+    context.superuser.set_password(password)
+    context.superuser.save()
+    context.superuser_email = email
+    context.superuser_password = password
+
+
+@when("the user navigates to the Django Admin login page")
+def when_navigate_admin_login(context):
+    context.response = context.test.client.get("/admin/login/", follow=True)
+    context.test.assertEqual(context.response.status_code, 200)
+    context.test.assertTemplateUsed(context.response, "allauth/layouts/base.html")
+
+
+@when("the user enters valid credentials")
+def when_enter_valid_credentials(context):
+    # Use Django's test client login method
+    login_success = context.test.client.login(
+        email=context.superuser_email, password=context.superuser_password
+    )
+    context.test.assertTrue(login_success)
+    # Load the admin dashboard page, mimicking the `next=` behavior
+    context.response = context.test.client.get("/admin/")
+
+
+@then("the Django Admin dashboard is displayed")
+def then_admin_dashboard_displayed(context):
+    context.test.assertEqual(context.response.status_code, 200)
+
+    soup = BeautifulSoup(context.response.content, "html.parser")
+    title_text = soup.find("title").text
+    context.test.assertEqual(title_text, "Site administration | Django site admin")

--- a/features/steps/user_dashboard.py
+++ b/features/steps/user_dashboard.py
@@ -1,0 +1,419 @@
+from datetime import datetime, timedelta
+from behave import given, when, then
+from django.contrib.auth import get_user_model
+from bs4 import BeautifulSoup
+from stave.models import (
+    League,
+    Event,
+    ApplicationForm,
+    Application,
+    ApplicationStatus,
+    RoleGroup,
+    ApplicationKind,
+    ApplicationAvailabilityKind,
+    LeagueUserPermission,
+    UserPermission,
+    EventStatus,
+)
+
+
+@given("a regular user exists")
+def given_regular_user_exists(context):
+    # TODO: Replace with a Factory pattern
+    User = get_user_model()
+    email = "user@example.com"
+    password = "password123"
+    context.user = User.objects.create(
+        email=email,
+        preferred_name="Test User",
+        is_superuser=False,
+        is_staff=False,
+    )
+    context.user.set_password(password)
+    context.user.save()
+    context.user_email = email
+    context.user_password = password
+
+
+@given("there are open application forms available")
+def given_open_application_forms(context):
+    # Create a league and event with open application forms
+    # TODO: Replace with a Factory pattern
+    league = League.objects.create(
+        name="Test League",
+        slug="test-league",
+        location="Test City",
+        enabled=True,
+    )
+
+    future_date = datetime.now() + timedelta(days=30)
+
+    event = Event.objects.create(
+        name="Test Event",
+        slug="test-event",
+        league=league,
+        start_date=future_date.date(),
+        end_date=future_date.date(),
+        status=EventStatus.OPEN,
+    )
+
+    role_group = RoleGroup.objects.create(name="Test Role", league=league)
+
+    context.application_form = ApplicationForm.objects.create(
+        event=event,
+        slug="test-form",
+        close_date=future_date.date(),
+        application_kind=ApplicationKind.ASSIGN_ONLY,
+        application_availability_kind=ApplicationAvailabilityKind.WHOLE_EVENT,
+        intro_text="Test application form for testing purposes.",
+    )
+    context.application_form.role_groups.add(role_group)
+
+
+@given("the user has submitted applications")
+def given_user_has_applications(context):
+    # TODO: Replace with a Factory pattern
+    # Ensure we have an application form first
+    if not hasattr(context, "application_form"):
+        context.execute_steps("Given there are open application forms available")
+
+    context.application = Application.objects.create(
+        user=context.user,
+        form=context.application_form,
+        status=ApplicationStatus.APPLIED,
+    )
+
+
+@given("the user manages events")
+def given_user_manages_events(context):
+    # Give the user permissions to manage the league
+    # TODO: Replace with a Factory pattern
+    if not hasattr(context, "application_form"):
+        context.execute_steps("Given there are open application forms available")
+
+    # Add the user as an event manager
+    LeagueUserPermission.objects.create(
+        user=context.user,
+        league=context.application_form.event.league,
+        permission=UserPermission.EVENT_MANAGER,
+    )
+
+    # Create some applications to test pending/open indicators
+    User = get_user_model()
+
+    # Create a user with an "open" application (status: APPLIED)
+    open_user = User.objects.create(
+        email="open@example.com",
+        preferred_name="Open User",
+        is_superuser=False,
+        is_staff=False,
+    )
+    open_user.set_password("password123")
+    open_user.save()
+
+    context.open_application = Application.objects.create(
+        user=open_user,
+        form=context.application_form,
+        status=ApplicationStatus.APPLIED,  # This is an "open" application
+    )
+
+    # Create a user with a "pending" application (status: INVITATION_PENDING)
+    pending_user = User.objects.create(
+        email="pending@example.com",
+        preferred_name="Pending User",
+        is_superuser=False,
+        is_staff=False,
+    )
+    pending_user.set_password("password123")
+    pending_user.save()
+
+    context.pending_application = Application.objects.create(
+        user=pending_user,
+        form=context.application_form,
+        status=ApplicationStatus.INVITATION_PENDING,  # This is a "pending" application
+    )
+
+
+@when("the user navigates to the home page")
+def when_navigate_home(context):
+    context.response = context.test.client.get("/", follow=True)
+    context.test.assertEqual(context.response.status_code, 200)
+
+
+@when("an unauthenticated user navigates to the home page")
+def when_unauthenticated_navigate_home(context):
+    # Ensure we're not logged in
+    context.test.client.logout()
+    context.response = context.test.client.get("/", follow=True)
+    context.test.assertEqual(context.response.status_code, 200)
+
+
+@when("the user logs in with valid credentials")
+def when_login_with_valid_credentials(context):
+    # Use Django's test client login method
+    login_success = context.test.client.login(
+        email=context.user_email, password=context.user_password
+    )
+    context.test.assertTrue(login_success)
+    # Reload the home page after login
+    context.response = context.test.client.get("/")
+
+
+@then("the user home page is displayed")
+def then_home_page_displayed(context):
+    context.test.assertEqual(context.response.status_code, 200)
+    context.test.assertTemplateUsed(context.response, "stave/home.html")
+
+    soup = BeautifulSoup(context.response.content, "html.parser")
+    # Check for welcome message
+    welcome_text = soup.find(text=lambda t: t and "Welcome to Stave" in t)
+    context.test.assertIsNotNone(welcome_text)
+
+
+@then('the user sees the "{section_name}" section')
+def then_user_sees_section(context, section_name):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+    section_header = soup.find("h2", string=section_name)
+    context.test.assertIsNotNone(
+        section_header, f"Could not find '{section_name}' section header"
+    )
+
+
+@then("the user sees their calendar widget")
+def then_user_sees_calendar(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+    # Look for calendar include or calendar-related elements
+    calendar_elements = soup.find_all(string=lambda t: t and "calendar" in t.lower())
+    context.test.assertTrue(len(calendar_elements) > 0, "Calendar widget not found")
+
+
+@then('the user sees "{message}" in the My Applications section')
+def then_user_sees_message_in_applications(context, message):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find the My Applications section
+    my_apps_header = soup.find("h2", string="My Applications")
+    context.test.assertIsNotNone(my_apps_header)
+
+    # Look for the message in the same article
+    article = my_apps_header.find_parent("article")
+    message_text = article.find(text=lambda t: t and message in t)
+    context.test.assertIsNotNone(
+        message_text, f"Could not find message '{message}' in My Applications section"
+    )
+
+
+@then('the user sees "{message}" in the My Events section')
+def then_user_sees_message_in_events(context, message):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find the My Events section
+    my_events_header = soup.find("h2", string="My Events")
+    context.test.assertIsNotNone(my_events_header)
+
+    # Look for the message in the same article
+    article = my_events_header.find_parent("article")
+    message_text = article.find(text=lambda t: t and message in t)
+    context.test.assertIsNotNone(
+        message_text, f"Could not find message '{message}' in My Events section"
+    )
+
+
+@then("the user can see application forms grouped by event")
+def then_application_forms_grouped_by_event(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find the Open Applications section
+    open_apps_header = soup.find("h2", string="Open Applications")
+    context.test.assertIsNotNone(open_apps_header)
+
+    # Look for event links in the same article
+    article = open_apps_header.find_parent("article")
+    event_links = article.find_all("a", href=True)
+    context.test.assertTrue(
+        len(event_links) > 0, "No event links found in Open Applications"
+    )
+
+
+@then("each application form shows the roles available")
+def then_application_shows_roles(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for "Apply as" text which indicates roles
+    apply_links = soup.find_all(text=lambda t: t and "Apply as" in t)
+    context.test.assertTrue(
+        len(apply_links) > 0, "No role information found in applications"
+    )
+
+
+@then("each application form shows the closing date if applicable")
+def then_application_shows_closing_date(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for closing date information
+    closes_text = soup.find_all(text=lambda t: t and "closes" in t)
+    context.test.assertTrue(
+        len(closes_text) > 0,
+        "Expected to find closing date information for application forms",
+    )
+
+
+@then("the user can click on application links to apply")
+def then_user_can_click_application_links(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find links that contain "/apply/" in the href or "Apply" in the text
+    apply_links = soup.find_all("a", href=True)
+    application_links = [
+        link
+        for link in apply_links
+        if "/apply/" in link.get("href", "") or "Apply" in link.get_text()
+    ]
+    context.test.assertTrue(len(application_links) > 0, "No application links found")
+
+
+@then('the user sees their applications in the "My Applications" section')
+def then_user_sees_their_applications(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find the My Applications section
+    my_apps_header = soup.find("h2", string="My Applications")
+    context.test.assertIsNotNone(my_apps_header)
+
+    # Look for application links in the same article
+    article = my_apps_header.find_parent("article")
+    app_links = article.find_all("a", href=True)
+    context.test.assertTrue(
+        len(app_links) > 0, "No application links found in My Applications"
+    )
+
+
+@then("each application shows the event name")
+def then_application_shows_event_name(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # The event name should be in the application link text
+    my_apps_header = soup.find("h2", string="My Applications")
+    article = my_apps_header.find_parent("article")
+
+    # Look for the test event name
+    event_text = article.find(text=lambda t: t and "Test Event" in t)
+    context.test.assertIsNotNone(event_text, "Event name not found in application")
+
+
+@then("each application shows the current status")
+def then_application_shows_status(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Status should be shown in parentheses
+    status_text = soup.find(text=lambda t: t and "Applied" in t)
+    context.test.assertIsNotNone(status_text, "Application status not found")
+
+
+@then("the user can click on applications to view details")
+def then_user_can_click_applications(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find My Applications section and look for application/<uuid>/ URLs
+    my_apps_header = soup.find("h2", string="My Applications")
+    article = my_apps_header.find_parent("article")
+
+    app_links = article.find_all("a", href=True)
+    view_links = [link for link in app_links if "/application/" in link.get("href", "")]
+    context.test.assertTrue(len(view_links) > 0, "No view application links found")
+
+
+@then('the user sees their events in the "My Events" section')
+def then_user_sees_their_events(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Find the My Events section
+    my_events_header = soup.find("h2", string="My Events")
+    context.test.assertIsNotNone(my_events_header)
+
+    # Look for event links in the same article
+    article = my_events_header.find_parent("article")
+    event_links = article.find_all("a", href=True)
+    context.test.assertTrue(len(event_links) > 0, "No event links found in My Events")
+
+
+@then("each event shows application forms with role groups")
+def then_event_shows_application_forms(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for role group names in the My Events section
+    my_events_header = soup.find("h2", string="My Events")
+    article = my_events_header.find_parent("article")
+
+    # Look for role group information
+    role_text = article.find(text=lambda t: t and "Test Role" in t)
+    context.test.assertIsNotNone(role_text, "Role group information not found")
+
+
+@then("pending applications are highlighted with counts")
+def then_pending_applications_highlighted(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for pending application indicators
+    pending_elements = soup.find_all("span", class_="cta")
+    pending_found = any(
+        "pending" in elem.get_text().lower() for elem in pending_elements
+    )
+    context.test.assertTrue(
+        pending_found,
+        "Expected to find pending application indicators for event managers",
+    )
+
+
+@then("open applications are highlighted with counts")
+def then_open_applications_highlighted(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for open application indicators
+    open_elements = soup.find_all("span", class_="cta")
+    open_found = any("open" in elem.get_text().lower() for elem in open_elements)
+    context.test.assertTrue(
+        open_found,
+        "Expected to find open application indicators for event managers",
+    )
+
+
+@then("multiple embedded video tutorials are displayed")
+def then_video_tutorials_displayed(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    # Look for iframe elements (YouTube embeds)
+    iframes = soup.find_all("iframe")
+    youtube_iframes = [
+        iframe for iframe in iframes if "youtube" in iframe.get("src", "")
+    ]
+    context.test.assertTrue(
+        len(youtube_iframes) >= 4,
+        f"Expected at least 4 YouTube videos, found {len(youtube_iframes)}",
+    )
+
+
+@then('the user sees the "Join Now" section instead of personalized content')
+def then_user_sees_join_now_section(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+    join_now_header = soup.find("h2", string="Join Now")
+    context.test.assertIsNotNone(
+        join_now_header, "Join Now section not found for unauthenticated user"
+    )
+
+
+@then('the user does not see "My Applications" or "My Events" sections')
+def then_user_does_not_see_personal_sections(context):
+    soup = BeautifulSoup(context.response.content, "html.parser")
+
+    my_apps_header = soup.find("h2", string="My Applications")
+    context.test.assertIsNone(
+        my_apps_header,
+        "My Applications section should not be visible to unauthenticated users",
+    )
+
+    my_events_header = soup.find("h2", string="My Events")
+    context.test.assertIsNone(
+        my_events_header,
+        "My Events section should not be visible to unauthenticated users",
+    )

--- a/features/user_dashboard.feature
+++ b/features/user_dashboard.feature
@@ -1,0 +1,64 @@
+Feature: User Dashboard and Home Page
+
+    As a logged-in user
+    I want to see my personalized dashboard
+    So that I can quickly access my applications, events, and available opportunities
+
+Background:
+    Given a regular user exists
+
+Scenario: Authenticated user sees personalized dashboard sections
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user home page is displayed
+    And the user sees the "Open Applications" section
+    And the user sees the "My Applications" section
+    And the user sees the "My Events" section
+    And the user sees the "Video Guides" section
+    And the user sees their calendar widget
+
+Scenario: User with no applications sees empty state messages
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user sees "You don't have any open applications right now." in the My Applications section
+    And the user sees "You aren't managing any events." in the My Events section
+
+Scenario: User can access application links from Open Applications section
+    Given there are open application forms available
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user can see application forms grouped by event
+    And each application form shows the roles available
+    And each application form shows the closing date if applicable
+    And the user can click on application links to apply
+
+Scenario: User can view their submitted applications
+    Given the user has submitted applications
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user sees their applications in the "My Applications" section
+    And each application shows the event name
+    And each application shows the current status
+    And the user can click on applications to view details
+
+Scenario: Event manager sees their managed events
+    Given the user manages events
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user sees their events in the "My Events" section
+    And each event shows application forms with role groups
+    And pending applications are highlighted with counts
+    And open applications are highlighted with counts
+
+Scenario: User can access video guides
+    When the user navigates to the home page
+    And the user logs in with valid credentials
+    Then the user sees the "Video Guides" section
+    And multiple embedded video tutorials are displayed
+
+Scenario: Unauthenticated user sees limited content
+    When an unauthenticated user navigates to the home page
+    Then the user sees the "Open Applications" section
+    And the user sees the "Join Now" section instead of personalized content
+    And the user sees the "Video Guides" section
+    And the user does not see "My Applications" or "My Events" sections

--- a/justfile
+++ b/justfile
@@ -18,7 +18,6 @@ migrate:
 
 # Run server in development mode
 run:
-    uv run manage.py collectstatic --noinput
     uv run manage.py runserver 0.0.0.0:8888
 
 # Run server in production mode

--- a/justfile
+++ b/justfile
@@ -32,3 +32,7 @@ seed: migrate
 # Run tests
 test:
     uv run pytest
+
+# Run behavioral tests
+behave arguments="":
+    uv run manage.py behave {{arguments}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "behave-django>=1.7.0",
     "django-debug-toolbar>=5.2.0",
     "django-extensions>=3.2.3",
     "pytest-django>=4.11.1",
@@ -46,3 +47,9 @@ reportExplicitAny = false
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "stave.settings"
+
+[tool.uv]
+# behave-django 1.7.0 relies on a prerelease version of behave
+# Remove this once behave-django updates to a stable release with behave 1.3.x
+# See https://github.com/behave/behave-django/pull/172
+prerelease = "if-necessary"

--- a/stave/settings/base.py
+++ b/stave/settings/base.py
@@ -123,7 +123,7 @@ STORAGES = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
 

--- a/stave/settings/development.py
+++ b/stave/settings/development.py
@@ -14,6 +14,7 @@ DEBUG = True
 INSTALLED_APPS += [
     "debug_toolbar",
     "django_extensions",  # Useful development tools like shell_plus
+    "behave_django",  # BDD testing framework
 ]
 
 # Add debug toolbar middleware at the beginning for development

--- a/stave/settings/production.py
+++ b/stave/settings/production.py
@@ -6,3 +6,13 @@ from .base import *  # noqa
 
 # Security settings
 DEBUG = False
+
+# Production static files storage with compression and hashing
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
+[options]
+prerelease-mode = "if-necessary"
+
 [[package]]
 name = "apscheduler"
 version = "3.11.0"
@@ -21,6 +24,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186, upload-time = "2024-03-22T14:39:36.863Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/e3/893e8757be2612e6c266d9bb58ad2e3651524b5b40cf56761e985a28b13e/asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47", size = 23828, upload-time = "2024-03-22T14:39:34.521Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
+]
+
+[[package]]
+name = "behave"
+version = "1.2.7.dev6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "cucumber-expressions" },
+    { name = "cucumber-tag-expressions" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b7/be3a5fb5ed211c6a4833989197879c07845019faa59eba0106482e8e16ac/behave-1.2.7.dev6.tar.gz", hash = "sha256:6e8791901c518bdbd41a99df6574127f53d9cb651e451268d3c50741941de0bf", size = 827062, upload-time = "2024-09-24T04:38:57.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/89/93f6e97a3b2ba68de26b42a67ba03f9aa92f2691a7724d9c86137b1266f3/behave-1.2.7.dev6-py2.py3-none-any.whl", hash = "sha256:b4f1535249414f6cca544870f62ca7291002eedb66ddc154cff20b363bd77e09", size = 201938, upload-time = "2024-09-24T04:38:55.4Z" },
+]
+
+[[package]]
+name = "behave-django"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "behave" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/18/f048fa69fda88943f317455ab439ce9c32960c1ba771e05e0bd68f3a41d6/behave_django-1.7.0.tar.gz", hash = "sha256:e253a4abc748559a0f9ad019349244fb0e4287f9cc70790dd0d20f3daf23c19e", size = 16355, upload-time = "2025-07-18T00:37:15.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/c1/71406da03fa7ea3561cec5b879fd444fb158ac66120cb4d30df913d88506/behave_django-1.7.0-py3-none-any.whl", hash = "sha256:ab842fec0ed267cfc77d209a5fad574a152f247f798cec0eb18a9f9480995d1f", size = 12535, upload-time = "2025-07-18T00:37:14.837Z" },
 ]
 
 [[package]]
@@ -172,6 +219,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/75/82a14bf047a96a1b13ebb47fb9811c4f73096cfa2e2b17c86879687f9027/cryptography-45.0.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:944e9ccf67a9594137f942d5b52c8d238b1b4e46c7a0c2891b7ae6e01e7c80a4", size = 4560964, upload-time = "2025-06-10T00:03:20.06Z" },
     { url = "https://files.pythonhosted.org/packages/cd/37/1a3cba4c5a468ebf9b95523a5ef5651244693dc712001e276682c278fc00/cryptography-45.0.4-cp37-abi3-win32.whl", hash = "sha256:c22fe01e53dc65edd1945a2e6f0015e887f84ced233acecb64b4daadb32f5c97", size = 2924557, upload-time = "2025-06-10T00:03:22.563Z" },
     { url = "https://files.pythonhosted.org/packages/2a/4b/3256759723b7e66380397d958ca07c59cfc3fb5c794fb5516758afd05d41/cryptography-45.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:627ba1bc94f6adf0b0a2e35d87020285ead22d9f648c7e75bb64f367375f3b22", size = 3395508, upload-time = "2025-06-10T00:03:24.586Z" },
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "18.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/7d/f4e231167b23b3d7348aa1c90117ce8854fae186d6984ad66d705df24061/cucumber_expressions-18.0.1.tar.gz", hash = "sha256:86ce41bf28ee520408416f38022e5a083d815edf04a0bd1dae46d474ca597c60", size = 22232, upload-time = "2024-10-28T11:38:48.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/e0/31ce90dad5234c3d52432bfce7562aa11cda4848aea90936a4be6c67d7ab/cucumber_expressions-18.0.1-py3-none-any.whl", hash = "sha256:86230d503cdda7ef35a1f2072a882d7d57c740aa4c163c82b07f039b6bc60c42", size = 20211, upload-time = "2024-10-28T11:38:47.101Z" },
+]
+
+[[package]]
+name = "cucumber-tag-expressions"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/81/32a2dc51c0720b34f642a6e79da6d89525c1eafd8902798026c233201f6f/cucumber_tag_expressions-6.2.0.tar.gz", hash = "sha256:b60aa2cdbf9ac43e28d9b0e4fd49edf9f09d5d941257d2912f5228f9d166c023", size = 41459, upload-time = "2025-05-25T12:30:43.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/99/0e9ac5b8429f39a05de5cd4731eac57738ce030dcd852aefe36a7102a4ce/cucumber_tag_expressions-6.2.0-py2.py3-none-any.whl", hash = "sha256:f94404b656831c56a3815da5305ac097003884d2ae64fa51f5f4fad82d97e583", size = 9333, upload-time = "2025-05-25T12:30:41.408Z" },
 ]
 
 [[package]]
@@ -507,6 +572,28 @@ wheels = [
 ]
 
 [[package]]
+name = "parse"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "11.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +854,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -802,6 +898,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "behave-django" },
     { name = "django-debug-toolbar" },
     { name = "django-extensions" },
     { name = "pre-commit" },
@@ -832,6 +929,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "behave-django", specifier = ">=1.7.0" },
     { name = "django-debug-toolbar", specifier = ">=5.2.0" },
     { name = "django-extensions", specifier = ">=3.2.3" },
     { name = "pre-commit", specifier = ">=4.0.0" },


### PR DESCRIPTION
Behavioral testing by using `behave` and `behave-django`.

- Express a feature of django admin, and run test clients against it.
- Multiple user scenarios with many steps to demonstrate some of the expressiveness available.

Left notes to refactor to Factory patterns when we have test factories.

While these tests are indeed slower, as they bootstrap an entire application context and call with a web test client, the scenarios help describe the overall intent of a feature flow.