### PR TITLE
Add K.O. Belle to contributors and fix development env email backend

### DIFF
--- a/docs/src/contributors.md
+++ b/docs/src/contributors.md
@@ -5,3 +5,4 @@ Contributors are listed in chronological order.
 - Stacktrace / David Reed
 - Badelynn / Madelynn Blue
 - Ref in Peace / Mike Fiedler
+- K.O. Belle / Charlie Humphreys (jeddai)

--- a/stave/settings/development.py
+++ b/stave/settings/development.py
@@ -29,7 +29,7 @@ INTERNAL_IPS = [
 
 # Development email backend - Use console backend for local development
 if not os.environ.get("EMAIL_BACKEND"):
-    EMAIL_BACKEND = "django.core.email.backends.console.EmailBackend"
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Allow verbose error pages
 DEBUG_PROPAGATE_EXCEPTIONS = True


### PR DESCRIPTION
I ran into an issue with the email backend when developing locally.

Reproduction steps:

1. Setup env
```bash
# run migrations locally
uv run manage.py migrate

# run server
uv run gunicorn stave.wsgi:application --bind 0.0.0.0:8888
```
2. Try to create a user - enter information and click "Sign Up"

3. Observe behavior
    * Actual (on `main`): internal server error
    * Expected (on this branch): application moves on, and email output is printed to console