### PR TITLE
Set up HTMX and add button to subscribe to leagues

### DIFF
--- a/stave/models.py
+++ b/stave/models.py
@@ -294,6 +294,13 @@ class Subscription(models.Model):
         League, related_name="subscribers", on_delete=models.CASCADE
     )
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "league"], name="unique_subscription"
+            )
+        ]
+
 
 class LeagueTemplate(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/stave/settings/base.py
+++ b/stave/settings/base.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_htmx",
     "allauth",
     "allauth.account",
     "allauth.mfa",
@@ -77,6 +78,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "django_htmx.middleware.HtmxMiddleware",
 ]
 
 # Authentication

--- a/stave/templates/base.html
+++ b/stave/templates/base.html
@@ -1,3 +1,4 @@
+{% load django_htmx %}
 {% load static %}
 {% load meta %}
 <!doctype html>
@@ -12,12 +13,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="color-scheme" content="light dark">
         <title>{% block title %}Stave{% endblock %}</title>
+        {% htmx_script %}
         {% include 'meta/meta.html' %}
         {% block resources %}{% endblock %}
         {% block extra_head %}
         {% endblock extra_head %}
     </head>
-    <body>
+    <body hx-headers='{"x-csrftoken": "{{ csrf_token }}"}'>
     <header class="container">
         <nav>
             <div>

--- a/stave/templates/stave/league_detail.html
+++ b/stave/templates/stave/league_detail.html
@@ -24,7 +24,16 @@
 
 <section>
 <header>
-    <h2>Upcoming Events</h2>
+    <div style="display: flex; flex-direction: row; justify-content: space-between; width: 100%;">
+        <h2>Upcoming Events</h2>
+        <button hx-get="/_/{{ league.slug }}/toggle-subscribed" hx-swap="innerHTML">
+            {% if request.user|is_subscribed_to:league %}
+            Unsubscribe
+            {% else %}
+            Subscribe
+            {% endif %}
+        </button>
+    </div>
     {% if request.user|can_manage_league_events:league %}
     <div class="inline">
     <a role="button" href="{% url 'event-create' league.slug %}">Create Event</a>

--- a/stave/templatetags/stave_tags.py
+++ b/stave/templatetags/stave_tags.py
@@ -107,6 +107,11 @@ def can_manage_league_events(user: models.User, league: models.League) -> bool:
 
 
 @register.filter
+def is_subscribed_to(user: models.User, league: models.League) -> bool:
+    return len(user.subscriptions.filter(league=league)) > 0
+
+
+@register.filter
 def can_manage_event(user: models.User, event: models.Event) -> bool:
     if user.is_authenticated:
         return models.LeagueUserPermission.objects.filter(

--- a/stave/urls.py
+++ b/stave/urls.py
@@ -30,6 +30,11 @@ urlpatterns = [
     ),
     path("_/<slug:slug>/", view=views.LeagueDetailView.as_view(), name="league-detail"),
     path(
+        "_/<slug:slug>/toggle-subscribed",
+        view=views.league_toggle_subscribed,
+        name="league-toggle-subscribed",
+    ),
+    path(
         "_/<slug:slug>/edit/", view=views.LeagueUpdateView.as_view(), name="league-edit"
     ),
     path(

--- a/stave/views.py
+++ b/stave/views.py
@@ -929,6 +929,19 @@ class LeagueDetailView(
         )
 
 
+def league_toggle_subscribed(request, slug):
+    if request.htmx and models.League.objects.visible(request.user):
+        league = models.League.objects.get(slug=slug)
+        if len(request.user.subscriptions.filter(league=league)) > 0:
+            request.user.subscriptions.filter(league=league).delete()
+            return HttpResponse("Subscribe")
+        else:
+            request.user.subscriptions.create(league=league)
+            return HttpResponse("Unsubscribe")
+    else:
+        return HttpResponseBadRequest("")
+
+
 class LeagueListView(generic.ListView):
     template_name = "stave/league_list.html"
     model = models.League


### PR DESCRIPTION
As it is now, this accomplishes part of #11, namely adding a button for users to subscribe to leagues and updating the database/UI accordingly. Full list of things changed here:

- Unique constraint on `User` and `League` added to `Subscription` model
- HTMX enabled in Django configs and base HTML
- New function-based "view" and url added for toggling subscribed state
    - This view returns only the innerHTML content that should be replaced in the "Subscribe" button
- Template tag filter for checking League subscription status

The remaining part is sending emails to subscribers, though I'm not entirely sure how to go about doing that based on the current structure of the code. @davidmreed if you have any guidance there it would be greatly appreciated!