### PR TITLE
Set up Fluent, Django localization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "sentry-sdk[django]>=2.24.0",
     "django-anymail[amazon-ses]>=13.0",
     "django-meta>=2.5.0",
+    "django-ftl>=0.14",
 ]
 
 [dependency-groups]

--- a/stave/ftl_bundles.py
+++ b/stave/ftl_bundles.py
@@ -1,0 +1,3 @@
+from django_ftl.bundles import Bundle
+
+base = Bundle(["stave/base.ftl"])

--- a/stave/locales/en/stave/base.ftl
+++ b/stave/locales/en/stave/base.ftl
@@ -1,0 +1,14 @@
+application-name=Stave
+
+navbar-leagues=Leagues
+navbar-events=Events
+navbar-docs=Docs
+navbar-my-account=My Account
+navbar-logout=Logout
+navbar-signup=Sign Up
+navbar-login=Login
+
+# HTML, do not translate anything within angle brackets (<>)
+footer-free-and-open-source-html=<a target="_blank" href="https://github.com/davidmreed/stave">Free and open source</a> for the roller derby community.
+footer-about=About
+footer-privacy=Privacy

--- a/stave/locales/es/stave/base.ftl
+++ b/stave/locales/es/stave/base.ftl
@@ -1,0 +1,14 @@
+application-name=Stave
+
+navbar-leagues=Ligas
+navbar-events=Eventos
+navbar-docs=Docs
+navbar-my-account=Mi Cuenta
+navbar-logout=Cerrar Sesión
+navbar-signup=Inscribirse
+navbar-login=Iniciar Sesión
+
+# HTML, do not translate anything within angle brackets (<>)
+footer-free-and-open-source-html=<a target="_blank" href="https://github.com/davidmreed/stave">Free and open source</a> for the roller derby community.
+footer-about=Acerca de
+footer-privacy=Privacidad

--- a/stave/settings/base.py
+++ b/stave/settings/base.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_ftl.apps.DjangoFtlConfig",
     "allauth",
     "allauth.account",
     "allauth.mfa",
@@ -77,6 +78,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
+    "django_ftl.middleware.activate_from_request_language_code",
 ]
 
 # Authentication

--- a/stave/templates/base.html
+++ b/stave/templates/base.html
@@ -1,3 +1,5 @@
+{% load ftl %}
+{% ftlconf bundle='stave.ftl_bundles.base' %}
 {% load static %}
 {% load meta %}
 <!doctype html>
@@ -11,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="color-scheme" content="light dark">
-        <title>{% block title %}Stave{% endblock %}</title>
+        <title>{% block title %}{% ftlmsg 'application-name' %}{% endblock %}</title>
         {% include 'meta/meta.html' %}
         {% block resources %}{% endblock %}
         {% block extra_head %}
@@ -22,20 +24,20 @@
         <nav>
             <div>
             <ul>
-                <li><a href="{% url 'home' %}"><strong>Stave</strong></a> <small><strong style="color: darkred;">BETA</strong></small></li>
-                <li><a href="{% url 'league-list' %}">Leagues</a></li>
-                <li><a href="{% url 'event-list' %}">Events</a></li>
-                <li><a target="_blank" href="https://docs.stave.app/">Docs</a></li>
+                <li><a href="{% url 'home' %}"><strong>{% ftlmsg 'application-name' %}</strong></a> <small><strong style="color: darkred;">BETA</strong></small></li>
+                <li><a href="{% url 'league-list' %}">{% ftlmsg 'navbar-leagues' %}</a></li>
+                <li><a href="{% url 'event-list' %}">{% ftlmsg 'navbar-events' %}</a></li>
+                <li><a target="_blank" href="https://docs.stave.app/">{% ftlmsg 'navbar-docs' %}</a></li>
             </ul>
             </div>
             <div>
                 <ul>
                 {% if request.user.is_authenticated %}
-                <li><a href="{% url 'profile' %}">My Account</a></li>
-                <li><a href="{% url 'account_logout' %}">Logout</a></li>
+                <li><a href="{% url 'profile' %}">{% ftlmsg 'navbar-my-account' %}</a></li>
+                <li><a href="{% url 'account_logout' %}">{% ftlmsg 'navbar-logout' %}</a></li>
                 {% else %}
-                <li><a href="{% url 'account_signup' %}">Sign Up</a></li>
-                <li><a href="{% url 'account_login' %}{% querystring next=request.path %}">Login</a></li>
+                <li><a href="{% url 'account_signup' %}">{% ftlmsg 'navbar-signup' %}</a></li>
+                <li><a href="{% url 'account_login' %}{% querystring next=request.path %}">{% ftlmsg 'navbar-login' %}</a></li>
                 {% endif %}
                 </ul>
             </div>
@@ -55,10 +57,10 @@
     </main>
     <footer class="container">
         <small>
-            Stave &copy; 2025 <a href="https://ktema.org">David "Stacktrace" Reed</a>.
-            <a target="_blank" href="https://github.com/davidmreed/stave">Free and open source</a> for the roller derby community.
-            <a target="_blank" href="https://docs.stave.app/about.html">About</a>
-            <a target="_blank" href="https://docs.stave.app/privacy-policy.html">Privacy</a>
+            {% ftlmsg 'application-name' %} &copy; 2025 <a href="https://ktema.org">David "Stacktrace" Reed</a>.
+            {% ftlmsg 'footer-free-and-open-source-html' %}
+            <a target="_blank" href="https://docs.stave.app/about.html">{% ftlmsg 'footer-about' %}</a>
+            <a target="_blank" href="https://docs.stave.app/privacy-policy.html">{% ftlmsg 'footer-privacy' %}</a>
         </small>
     </footer>
     </body>

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,24 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.5"
 source = { registry = "https://pypi.org/simple" }
@@ -354,6 +372,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-ftl"
+version = "0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "fluent-compiler" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/ec/52747f9e6d955aadc291618b453f9f92ebf1335ea7d44c4b48f6dc9697bf/django-ftl-0.14.tar.gz", hash = "sha256:3f881f143dd6509175d5e0722407ddf42a84f4a10680ed972ed3b4c6ad2107aa", size = 46120, upload-time = "2023-02-16T20:23:04.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/bd/9db699374a4c01b8d7715d61cbc7948a26155a2de3e5d91f82cd9c762f0f/django_ftl-0.14-py3-none-any.whl", hash = "sha256:87e1b374fb307e9bfac402abc87b347212e02288ca2d333d27bdbc481c71e0bf", size = 12350, upload-time = "2023-02-16T20:23:03.397Z" },
+]
+
+[[package]]
 name = "django-htmx"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
@@ -496,6 +527,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
+name = "fluent-compiler"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "babel" },
+    { name = "fluent-syntax" },
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/32/b51e4b5708412ccd3bec1060216c711a5a36da3814346b1799652a9051af/fluent_compiler-1.1.tar.gz", hash = "sha256:7ab34182b7ef616233457bc7d17eca830aa8faa4685eed7e4498968d63cdf14e", size = 83700, upload-time = "2024-04-02T18:53:09.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/5c/f6fcde75c59a54209ee3a109d84506e82f55e24e77a3df0e2d5755b8a4b9/fluent_compiler-1.1-py3-none-any.whl", hash = "sha256:67486e9e12394c9c38c89705171ee965ca8163684ebaeff019d0fa23945e9827", size = 37272, upload-time = "2024-04-02T18:53:07.795Z" },
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/52/de75f2faf499ed5a089acff2ab8bda5fc3b8db8a3f1615428ef9ccbf1917/fluent.syntax-0.19.0.tar.gz", hash = "sha256:920326d7f46864b9758f0044e9968e3112198bc826acee16ddd8f11d359004fd", size = 15039, upload-time = "2023-03-16T11:03:24.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/28/475734afb670bf7932caa1828183a4687cac51111950b9fb633c4f976afc/fluent.syntax-0.19.0-py2.py3-none-any.whl", hash = "sha256:b352b3475fac6c6ed5f06527921f432aac073d764445508ee5218aeccc7cc5c4", size = 16432, upload-time = "2023-03-16T11:03:21.934Z" },
 ]
 
 [[package]]
@@ -807,6 +865,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -930,6 +997,7 @@ dependencies = [
     { name = "django-allauth", extra = ["mfa", "socialaccount"] },
     { name = "django-anymail", extra = ["amazon-ses"] },
     { name = "django-apscheduler" },
+    { name = "django-ftl" },
     { name = "django-htmx" },
     { name = "django-ical" },
     { name = "django-markdownify" },
@@ -963,6 +1031,7 @@ requires-dist = [
     { name = "django-allauth", extras = ["mfa", "socialaccount"], specifier = ">=65.3.1" },
     { name = "django-anymail", extras = ["amazon-ses"], specifier = ">=13.0" },
     { name = "django-apscheduler", specifier = ">=0.7.0" },
+    { name = "django-ftl", specifier = ">=0.14" },
     { name = "django-htmx", specifier = ">=1.21.0" },
     { name = "django-ical", specifier = ">=1.9.2" },
     { name = "django-markdownify", specifier = ">=0.9.5" },


### PR DESCRIPTION
#197

This sets up Fluent for the project, enables its middleware, and also enables Django's default localization middleware.

I took a stab at translating the navbar/footer links to Spanish based off my knowledge of Spanish, but if there's better translations for them then by all means please override my initial translations.

Easiest way to test this is:
1. Load the app (homepage is fine, but its content is not localized)
2. Change your browser's language to Spanish (es)
3. Refresh the app page, the navbar and footer links should be showing up in Spanish now!

Something I've noticed is Django's default middleware seems to change the language for various existing forms, such as the login form. I think on the whole we'll need to be adding translations for all of the text content that exists in our templates. 