### PR TITLE
test: isolate test database from dev db

### DIFF
--- a/stave/settings/base.py
+++ b/stave/settings/base.py
@@ -143,7 +143,10 @@ WSGI_APPLICATION = "stave.wsgi.application"
 DATABASES = {
     "default": dj_database_url.config(
         default="sqlite:///db.sqlite3", conn_max_age=600, conn_health_checks=True
-    )
+    ),
+    "TEST": {
+        "NAME": "memory",
+    },
 }
 
 


### PR DESCRIPTION
Prevent tests from creating or manipulating the development database by setting a test-specific configuration.