### PR TITLE
Document the application lifecycle as a finite state machine.

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,10 @@
 - [Messaging](./messaging.md)
 - [Templates & League Management](./league-management.md)
 
+# Developer Reference
+
+- [Application Lifecycle](./application-lifecycle.md)
+
 # Policies
 
 - [Privacy Policy](./privacy-policy.md)

--- a/docs/src/application-lifecycle.md
+++ b/docs/src/application-lifecycle.md
@@ -1,0 +1,42 @@
+# Application Lifecycle
+
+This diagram shows the finite state machine for the status of an application.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> APPLIED
+    state OPEN {
+        state application_kind <<choice>>
+        APPLIED --> application_kind
+        application_kind --> INVITATION_PENDING: [CONFIRM_THEN_ASSIGN]
+        application_kind --> ASSIGNMENT_PENDING: [ASSIGN_ONLY]
+        APPLIED --> REJECTION_PENDING
+        APPLIED --> REJECTED
+        APPLIED --> WITHDRAWN
+        INVITATION_PENDING --> APPLIED
+        INVITATION_PENDING --> INVITED
+        INVITATION_PENDING --> DECLINED
+        INVITATION_PENDING --> WITHDRAWN
+        INVITED --> CONFIRMED
+        INVITED --> DECLINED
+        INVITED --> WITHDRAWN
+        CONFIRMED --> ASSIGNMENT_PENDING
+        state "CONFIRMED (pseudostate)" as CONFIRMED
+        ASSIGNMENT_PENDING --> ASSIGNED
+        ASSIGNMENT_PENDING --> WITHDRAWN
+    }
+    state ROSTERED {
+        ASSIGNED --> WITHDRAWN
+    }
+    REJECTION_PENDING --> APPLIED
+    REJECTION_PENDING --> REJECTED
+    REJECTION_PENDING --> WITHDRAWN
+    state CLOSED {
+        WITHDRAWN --> [*]
+        DECLINED --> [*]
+        REJECTED --> [*]
+    }
+```
+
+

--- a/docs/src/contributors.md
+++ b/docs/src/contributors.md
@@ -6,4 +6,4 @@ Contributors are listed in chronological order.
 - Badelynn / Madelynn Blue
 - Ref In Peace / [Mike Fiedler](https://github.com/miketheman)
 - K.O. Belle / Charlie Humphreys (jeddai)
-- Trampling Bias / Mark Rogaski (https://github.com/mrogaski)
+- Trampling Bias / [Mark Rogaski](https://github.com/mrogaski)


### PR DESCRIPTION
This change represents the application lifecycle as a finite state machine. The transitions conditioned by the application_kind are represented as a choice node and the CONFIRM state is represented as a pseudonode because of the automatic secondary transition that occurs on invite confirmation.

This will be used as a basis for the unit tests for the unit tests for logic encapsulation in #233.